### PR TITLE
Use matching source address for outgoing connections

### DIFF
--- a/sockssrv.c
+++ b/sockssrv.c
@@ -142,13 +142,15 @@ static int connect_socks_target(unsigned char *buf, size_t n, struct client *cli
 		}
 	}
 
-	local.sin_family = AF_INET;
-	local.sin_port = 0;
-	local.sin_addr.s_addr = inet_addr(bind_ip);
+	if(bind_ip != NULL) {
+		local.sin_family = AF_INET;
+		local.sin_port = 0;
+		local.sin_addr.s_addr = inet_addr(bind_ip);
 
-	// bind before connect to use the listen address as the outgoing address
-	if(bind(fd, (struct sockaddr*) &local, sizeof(local)) < 0)
-		goto eval_errno;
+		// bind before connect to use the listen address as the outgoing address
+		if(bind(fd, (struct sockaddr*) &local, sizeof(local)) < 0)
+			goto eval_errno;
+	}
 
 	if(connect(fd, remote->ai_addr, remote->ai_addrlen) == -1)
 		goto eval_errno;


### PR DESCRIPTION
For servers that have a network interface with more than one IP address, outgoing connections use whatever the default route prefers.

This PR will ensure that if microsocks listens on IP 1.2.3.4, that same IP will be used for outgoing connections instead of the server's default outgoing address, which may be a different one.