### PR TITLE
Added snap support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: microsocks
+version: '1.0.0'
+summary: tiny, portable SOCKS5 server with very moderate resource usage
+description: |
+  A SOCKS5 service that you can run on your remote boxes 
+  to tunnel connections through them, if for some reason SSH 
+  doesn't cut it for you.
+
+grade: stable
+confinement: strict
+
+apps:
+  microsocks:
+    command: usr/local/bin/microsocks
+    plugs: 
+      - network
+      - network-bind
+
+parts:
+  microsocks:
+    source: .
+    plugin: make
+    build-packages: 
+      - build-essential


### PR DESCRIPTION
Adds snap packaging support. 

With this patch, you can generate snap packages for six architectures (amd64, i386, armhf, arm64, ppc64el and s390x, assuming that the source can compile to those architectures)
by using the build servers at https://build.snapcraft.io/

A user would then need to run `sudo snap install microsocks` in order to install microsocks.

The snapcraft configuration forces the *strict* confinement and allows only two privileges: 
1. _network_, to access the network
2. _network-bind_, to listen to network port on the local computer