### PR TITLE
Fix two warnings found by gcc-9.2

### DIFF
--- a/sockssrv.c
+++ b/sockssrv.c
@@ -376,11 +376,11 @@ static void zero_arg(char *s) {
 }
 
 int main(int argc, char** argv) {
-	int c;
+	int ch;
 	const char *listenip = "0.0.0.0";
 	unsigned port = 1080;
-	while((c = getopt(argc, argv, ":1b:i:p:u:P:")) != -1) {
-		switch(c) {
+	while((ch = getopt(argc, argv, ":1b:i:p:u:P:")) != -1) {
+		switch(ch) {
 			case '1':
 				auth_ips = sblist_new(sizeof(union sockaddr_union), 8);
 				break;
@@ -403,6 +403,7 @@ int main(int argc, char** argv) {
 				break;
 			case ':':
 				dprintf(2, "error: option -%c requires an operand\n", optopt);
+				/* fall through */
 			case '?':
 				return usage();
 		}


### PR DESCRIPTION
Warnings were:
```
sockssrv.c: In function 'main':
sockssrv.c:430:17: warning: declaration of 'c' shadows a previous local [-Wshadow]
  430 |   struct client c;
      |                 ^
sockssrv.c:379:6: note: shadowed declaration is here
  379 |  int c;
      |      ^
sockssrv.c:405:5: warning: this statement may fall through [-Wimplicit-fallthrough=]
  405 |     dprintf(2, "error: option -%c requires an operand\n", optopt);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sockssrv.c:406:4: note: here
  406 |    case '?':
      |    ^~~~
```