### PR TITLE
Increase PTHREAD_STACK_MIN under FreeBSD

### DIFF
--- a/sockssrv.c
+++ b/sockssrv.c
@@ -44,7 +44,7 @@
 /* MAC says its min is 8KB, but then crashes in our face. thx hunkOLard */
 #undef PTHREAD_STACK_MIN
 #define PTHREAD_STACK_MIN 64*1024
-#elif defined(__GLIBC__)
+#elif defined(__GLIBC__) || defined(__FreeBSD__)
 #undef PTHREAD_STACK_MIN
 #define PTHREAD_STACK_MIN 32*1024
 #endif


### PR DESCRIPTION
Fix crash under FreeBSD in case DNS being proxied in addition to usual HTTP traffic.

Otherwise it crashes somewhere after getaddrinfo() call.
Tested it on FreeBSD 11.4, 12.1 and 13

Default FreeBSD's PTHREAD_STACK_MIN is 2Kb under i386/amd64 which is enough for usual HTTP traffic.
But once you configure your browser (Firefox, for example) to proxy DNS also, you'll see a crash like this:
```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00000008003e5467 in ?? () from /lib/libc.so.7
[Current thread is 1 (LWP 100282)]
(gdb) bt
#0  0x00000008003e5467 in ?? () from /lib/libc.so.7
#1  0x00000008003e4990 in ?? () from /lib/libc.so.7
#2  0x000000080040df6c in nsdispatch () from /lib/libc.so.7
#3  0x00000008003e30b3 in getaddrinfo () from /lib/libc.so.7
#4  0x0000000000203886 in resolve (host=0x7fffdfffda20 "js.callrail.com", port=443, addr=0x7fffdfffda18) at server.c:14
#5  0x00000000002030d8 in connect_socks_target (buf=0x7fffdfffdba0 "\005\001", n=22, client=0x800689038) at sockssrv.c:137
#6  0x00000000002029d3 in clientthread (data=0x800689030) at sockssrv.c:318
#7  0x000000080025a736 in ?? () from /lib/libthr.so.3
#8  0x0000000000000000 in ?? ()
Backtrace stopped: Cannot access memory at address 0x7fffdfffe000
```