### PR TITLE
Enable support for SO_MARK on Linux via compile-time flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,17 @@ Supported SOCKS5 Features
 - IPv4, IPv6, DNS
 - TCP (no UDP at this time)
 
+compile time options
+--------------------
+
+    make CFLAGS=-DSOMARK 
+
+microsocks can be compiled with SO_MARK support on linux 2.6.25+. This
+enables 'marking' of outgoing packets for use with policy-based routing
+which allows to route packets through a non-default interface. E.g.:
+
+    ip rule add fwmark 1000 table 200
+    ip route add default dev tun1 table 200
+    microsocks -m 1000
+
+will route all connections through device `tun1`

--- a/sockssrv.c
+++ b/sockssrv.c
@@ -404,8 +404,10 @@ int main(int argc, char** argv) {
 	unsigned port = 1080;
 #if defined(SOMARK)
 	somark = 0;
-#endif
+	while((ch = getopt(argc, argv, ":1b:i:m:p:u:P:")) != -1) {
+#else
 	while((ch = getopt(argc, argv, ":1b:i:p:u:P:")) != -1) {
+#endif
 		switch(ch) {
 			case '1':
 				auth_ips = sblist_new(sizeof(union sockaddr_union), 8);


### PR DESCRIPTION
This adds the `-m <mark_id>` option. SO_MARK allows to "mark" all outgoing packets with Linux-stack internal "tag". This enables the Linux network rules to identify these packets and make all sorts of decisions regarding routing and other packet processing.

Special compile flag is needed to enable.