### PR TITLE
Fix the resource exhausting issue. Every process has its maximum open…

### DIFF
--- a/sockssrv.c
+++ b/sockssrv.c
@@ -439,7 +439,12 @@ int main(int argc, char** argv) {
 		struct thread *curr = malloc(sizeof (struct thread));
 		if(!curr) goto oom;
 		curr->done = 0;
-		if(server_waitclient(&s, &c)) continue;
+		if(server_waitclient(&s, &c)) {
+			dolog("failed to accept connection\n");
+			free(curr);
+			usleep(1000);
+			continue;
+		}
 		curr->client = c;
 		if(!sblist_add(threads, &curr)) {
 			close(curr->client.fd);


### PR DESCRIPTION
Fix the resource exhausting issue. Every process has its maximum opened files limitation (by default 1024).
When the microsocks received too many connection requests, then the line "server_waitclient()" would failed
and re-try without any delay nor releasing allocated memory.
In this fix, whenever failed to service client properly, wait for 1 ms before accepting new connection.

Here are steps to reproduce issue quickly:
step 1: On server, execute "microsocks"
step 2: On server, limit the maximum FD down to 5 via
      `prlimit --pid <microsocks pid> --nofile=5:5`
step 3: On client, create connection to pass through socks server
step 4: Monitor the system with "htop" on server, the CPU utilization going high and memory usage is rising.
