### PR TITLE
add -B bind device option (follows up on #29)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ prefix = /usr/local
 bindir = $(prefix)/bin
 
 PROG = microsocks
-SRCS =  sockssrv.c server.c sblist.c sblist_delete.c
+SRCS =  sockssrv.c server.c sblist.c sblist_delete.c bind2device.c
 OBJS = $(SRCS:.c=.o)
 
 LIBS = -lpthread

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ libc is not even 50 KB. that's easily usable even on the cheapest routers.
 command line options
 --------------------
 
-    microsocks -1 -q -i listenip -p port -u user -P passw -b bindaddr -w wl
+    microsocks -1 -q -i listenip -p port -u user -P passw -b bindaddr -B bind2device -w wl
 
 all arguments are optional.
 by default listenip is 0.0.0.0 and port 1080.

--- a/bind2device.c
+++ b/bind2device.c
@@ -1,0 +1,55 @@
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+
+#define _GNU_SOURCE
+#define _DARWIN_C_SOURCE
+
+#include <errno.h>
+#include <netinet/in.h>
+#include <net/if.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <string.h>
+
+#include "bind2device.h"
+
+#if (defined(IP_BOUND_IF) || defined(IPV6_BOUND_IF))
+
+int bind2device(int sockfd, int socket_family, const char *device)
+{
+	int ifindex = if_nametoindex(device);
+	if (ifindex == 0)
+		return -1;
+	switch (socket_family)
+	{
+#if defined(IPV6_BOUND_IF)
+	case AF_INET6:
+		return setsockopt(sockfd, IPPROTO_IPV6, IPV6_BOUND_IF, &ifindex, sizeof(ifindex));
+#endif
+#if defined(IP_BOUND_IF)
+	case AF_INET:
+		return setsockopt(sockfd, IPPROTO_IP, IP_BOUND_IF, &ifindex, sizeof(ifindex));
+#endif
+	default: // can't bind to interface for selected socket_family: operation not supported on socket
+		errno = EOPNOTSUPP;
+		return -1;
+	}
+}
+
+#elif defined(SO_BINDTODEVICE)
+
+int bind2device(int sockfd, int socket_family, const char *device)
+{
+	return setsockopt(sockfd, SOL_SOCKET, SO_BINDTODEVICE, device, strlen(device) + 1);
+}
+
+#else
+#pragma message "Platform does not support bind2device, generating stub."
+
+int bind2device(int sockfd, int socket_family, const char *device)
+{
+	errno = ENOSYS; // unsupported platform: not implemented
+	return -1;
+}
+
+#endif

--- a/bind2device.h
+++ b/bind2device.h
@@ -1,0 +1,6 @@
+#ifndef BIND2DEVICE_H
+#define BIND2DEVICE_H
+
+int bind2device(int sockfd, int socket_family, const char* device);
+
+#endif


### PR DESCRIPTION
This follows up on https://github.com/rofl0r/microsocks/pull/29

- works on linux and macos
- dedicated file (ifdefs are in a single spot)
- doesn't break the build if feature is unsupported (use stub and return error if used)
- prints a build message if feature is unsupported

It could be integrated into ```socksrv.c``` as well, but ```#include <netinet/in.h>``` must be included with ```_GNU_SOURCE``` or ```_DARWIN_C_SOURCE``` set (depending on the platform) and this doesn't play well with the way the ```server.h``` currently works.


References:
- https://github.com/wine-mirror/wine/blob/wine-9.18/server/sock.c#L2151
- https://djangocas.dev/blog/linux/linux-SO_BINDTODEVICE-and-mac-IP_BOUND_IF-to-bind-socket-to-a-network-interface/
