### PR TITLE
Increase stack size up to 32K on OpenBSD

### DIFF
--- a/sockssrv.c
+++ b/sockssrv.c
@@ -56,7 +56,10 @@
 #if defined(__APPLE__)
 #undef THREAD_STACK_SIZE
 #define THREAD_STACK_SIZE 64*1024
-#elif defined(__GLIBC__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__sun__)
+#elif defined(__GLIBC__) || defined(__FreeBSD__) || defined(__sun__)
+#undef THREAD_STACK_SIZE
+#define THREAD_STACK_SIZE 32*1024
+#elif defined(__OpenBSD__) && defined(__clang__)
 #undef THREAD_STACK_SIZE
 #define THREAD_STACK_SIZE 32*1024
 #endif

--- a/sockssrv.c
+++ b/sockssrv.c
@@ -56,7 +56,7 @@
 #if defined(__APPLE__)
 #undef THREAD_STACK_SIZE
 #define THREAD_STACK_SIZE 64*1024
-#elif defined(__GLIBC__) || defined(__FreeBSD__) || defined(__sun__)
+#elif defined(__GLIBC__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__sun__)
 #undef THREAD_STACK_SIZE
 #define THREAD_STACK_SIZE 32*1024
 #endif


### PR DESCRIPTION
microsocks segfaults on OpenBSD when building with Clang. However, building it with -O0 make the issue gone with default 16K stack. GCC works good under any conditions.
32K stack works good on OpenBSD -current (7.6).