### PR TITLE
Fix some minor nits in the manual page

### DIFF
--- a/microsocks.1
+++ b/microsocks.1
@@ -15,7 +15,6 @@
 .Op Fl p Ar port
 .Op Fl u Ar user
 .Op Fl w Ar ips
-.Oc
 .El
 .Ek
 .Sh DESCRIPTION

--- a/microsocks.1
+++ b/microsocks.1
@@ -23,8 +23,10 @@ is a multithreaded, tiny, portable SOCKS5 server with very moderate resource
 usage that you can run on your remote boxes to tunnel connections through them,
 if for some reason SSH doesn't cut it for you.
 It is very lightweight, and very light on resources too: for every client, a
-thread with a low stack size is spawned. the main process basically doesn't
-consume any resources at all. It is also designed to be robust: it handles
+thread with a low stack size is spawned.
+The main process basically doesn't
+consume any resources at all.
+It is also designed to be robust: it handles
 resource exhaustion gracefully by simply denying new connections, instead of
 calling
 .Xr abort 3
@@ -38,10 +40,13 @@ The following options are supported by
 .It Fl 1
 Activates auth_once mode: once a specific IP address authorized successfully
 with user:password pair, it is added to a whitelist and may use the proxy
-without authorization. This is handy for programs like Firefox that don't
-support user:password authorization. For it to work you'd basically make one
+without authorization.
+This is handy for programs like Firefox that don't
+support user:password authorization.
+For it to work you'd basically make one
 connection with another program that supports it, and then you can use Firefox
-too. This option requires options
+too.
+This option requires options
 .Fl u
 and
 .Fl P
@@ -49,20 +54,25 @@ also to be specified.
 .It Fl b Ar ip
 Specifies IP address outgoing connections are bound to.
 .It Fl i Ar addr
-Specifies local address to listen connections on. Host name or IP address can be
-supplied. Default to
+Specifies local address to listen connections on.
+Host name or IP address can be
+supplied.
+Default to
 .Cm 0.0.0.0 .
 .It Fl P
-Specifies authorization password. This option requires
+Specifies authorization password.
+This option requires
 .Fl u
 also to be specified.
 .It Fl p
-TCP port to listen to. Default to
+TCP port to listen to.
+Default to
 .Cm 1080 .
 .It Fl q
 Quiet mode: suppress logging messages.
 .It Fl u
-Specifies authorization username value. This option requires
+Specifies authorization username value.
+This option requires
 .Fl P
 also to be specified.
 .It Fl w

--- a/microsocks.1
+++ b/microsocks.1
@@ -54,7 +54,7 @@ also to be specified.
 .It Fl b Ar ip
 Specifies IP address outgoing connections are bound to.
 .It Fl i Ar addr
-Specifies local address to listen connections on.
+Specifies local address to listen for connections on.
 Host name or IP address can be
 supplied.
 Default to
@@ -76,8 +76,8 @@ This option requires
 .Fl P
 also to be specified.
 .It Fl w
-A comma-separated whitelist of IP addresses, that may use the proxy without
-authentication. e.g.
+A comma-separated whitelist of IP addresses that may use the proxy without
+authentication, e.g.
 .Cm -w 127.0.0.1,192.168.1.1.1,::1
 or just
 .Cm -w 10.0.0.1 .


### PR DESCRIPTION
First of all, thanks a lot for writing and maintaining microsocks!

What do you think about these three commits? Two of them are trivial fixes, the third one - start sentences on a new line - is something I personally learned from my time as a FreeBSD doc committer; the FreeBSD project has a policy that mdoc manual pages should be written like that, both as a hint to the formatting software and also as a convenience when rewriting sentences: there is no need to reflow a whole paragraph that contains five or six sentences if you want to add four words to one of them.

Of course, it is your decision whether to accept these changes; let me know if you think that some of them are not needed, I can drop them from the branch.

BTW, it is great to see people writing mdoc manual pages! Over the years I have wondered why this is not more widespread; it is *so* much easier than using the "traditional" man macro set...

Thanks again, and keep up the great work!