### PR TITLE
Fix an "allows to" grammar nit

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ by default listenip is 0.0.0.0 and port 1080.
 
 - option -q disables logging.
 - option -b specifies which ip outgoing connections are bound to
-- option -w allows to specify a comma-separated whitelist of ip addresses,
+- option -w specifies a comma-separated whitelist of ip addresses,
 that may use the proxy without user/pass authentication.
 e.g. -w 127.0.0.1,192.168.1.1.1,::1 or just -w 10.0.0.1
 to allow access ONLY to those ips, choose an impossible to guess user/pw combo.

--- a/sockssrv.c
+++ b/sockssrv.c
@@ -391,7 +391,7 @@ static int usage(void) {
 		"by default listenip is 0.0.0.0 and port 1080.\n\n"
 		"option -q disables logging.\n"
 		"option -b specifies which ip outgoing connections are bound to\n"
-		"option -w allows to specify a comma-separated whitelist of ip addresses,\n"
+		"option -w specifies a comma-separated whitelist of ip addresses,\n"
 		" that may use the proxy without user/pass authentication.\n"
 		" e.g. -w 127.0.0.1,192.168.1.1.1,::1 or just -w 10.0.0.1\n"
 		" to allow access ONLY to those ips, choose an impossible to guess user/pw combo.\n"


### PR DESCRIPTION
Thanks again for writing and maintaining microsocks!

Here's a trivial change that follows the common English usage of "allow" - unlike some Slavic languages (trust me, I know :)), it should be used with an object, e.g. "allows one to", "allows you to", "allows the user to". I think that in these cases it is not needed at all, since the description of the other command-line options use "specifies" directly.