### PR TITLE
Feature/log timestamp

### DIFF
--- a/sockssrv.c
+++ b/sockssrv.c
@@ -35,6 +35,8 @@
 #include <limits.h>
 #include "server.h"
 #include "sblist.h"
+#include <time.h>
+#include <stdarg.h>
 
 /* timeout in microseconds on resource exhaustion to prevent excessive
    cpu usage. */
@@ -111,7 +113,20 @@ struct thread {
 /* we log to stderr because it's not using line buffering, i.e. malloc which would need
    locking when called from different threads. for the same reason we use dprintf,
    which writes directly to an fd. */
-#define dolog(...) do { if(!quiet) dprintf(2, __VA_ARGS__); } while(0)
+static inline void dolog(const char *fmt, ...) {
+    char t[32] = {};
+    struct tm tm_buf;
+    time_t secs = time(NULL);
+
+    va_list args;
+    va_start(args, fmt);
+
+    strftime(t, sizeof(t), "[%Y-%m-%d %T] ", localtime_r(&secs, &tm_buf));
+    dprintf(fileno(stderr), "%s", t);
+    vdprintf(fileno(stderr), fmt, args);
+
+    va_end(args);
+}
 #else
 static void dolog(const char* fmt, ...) { }
 #endif

--- a/sockssrv.c
+++ b/sockssrv.c
@@ -494,6 +494,7 @@ int main(int argc, char** argv) {
 		return 1;
 	}
 	server = &s;
+	dolog("Listening on %s:%d\n", listenip, port);
 
 	while(1) {
 		collect(threads);


### PR DESCRIPTION
Adding timestamp to stderr log, using dprintf, keeping the fmt option.
Also a startup message tells the bind address.